### PR TITLE
Add tanzu package installed list command to README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -226,6 +226,8 @@ The installation takes some time.
 10-30 mins.
 YMMV.
 
+To check on the installation process: `tanzu package installed list -A`
+
 === Workload Notes
 
 Deployed apps will be assigned an HTTP route of the form:


### PR DESCRIPTION
Just for visibility (I can never remember the `tanzu package installed list -A` command; might be nice to save it in the repo)